### PR TITLE
Add support for toggling recent items jump lists

### DIFF
--- a/Sophia Script/Sophia Script for Windows 10 PowerShell 7/Module/Sophia.psm1
+++ b/Sophia Script/Sophia Script for Windows 10 PowerShell 7/Module/Sophia.psm1
@@ -2278,6 +2278,57 @@ function QuickAccessFrequentFolders
 
 <#
 	.SYNOPSIS
+	Recently used items in Jump Lists on the taskbar 
+
+	.PARAMETER Hide
+	Hide recently used items in Jump Lists on the taskbar 
+
+	.PARAMETER Show
+	Show recently used items in Jump Lists on the taskbar 
+
+	.EXAMPLE
+	JumpListsRecentItems -Hide
+
+	.EXAMPLE
+	JumpListsRecentItems -Show
+
+	.NOTES
+	Current user
+#>
+function JumpListsRecentItems
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Hide"
+		)]
+		[switch]
+		$Hide,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Show"
+		)]
+		[switch]
+		$Show
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Hide"
+		{
+			New-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced -Name Start_TrackDocs -PropertyType DWord -Value 0 -Force
+		}
+		"Show"
+		{
+			New-ItemProperty -Path HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced -Name Start_TrackDocs -PropertyType DWord -Value 1 -Force
+		}
+	}
+}
+
+<#
+	.SYNOPSIS
 	Search on the taskbar
 
 	.PARAMETER Hide


### PR DESCRIPTION
I wasn't sure if I should've add it to the Sophia.ps1 and the other platforms already.

Furthermore I wasn't sure about the naming: _JumpListsRecentItems_ (like QuickAccessRecentFiles) or _RecentItemsJumpLists_



_Note: the group policy way would've been:_
```
[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer]
"NoRecentDocsHistory"=dword:00000001
```