### PR TITLE
Create .gitignore, exclude user-created scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Exclude user-created configurations
+/Sophia Script/*/*.ps1
+!/Sophia Script/*/Functions.ps1
+!/Sophia Script/*/Sophia.ps1


### PR DESCRIPTION
By default, user-created scripts (such as those created with SophiaScriptWrapper.exe) need to be saved to "/Sophia Script/*/SCRIPTNAME.ps1" in order to find the dependencies Sophia.ps1 and Functions.ps1.

Therefore, all user-created scripts in these directories should be excluded from git tracking.