### PR TITLE
Improved UninstallPCHealthCheck function performance

### DIFF
--- a/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
+++ b/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
@@ -9021,11 +9021,11 @@ function UninstallPCHealthCheck
 {
 	$Folder = (New-Object -ComObject Shell.Application).NameSpace("$env:SystemRoot\Installer")
 	$Files = [hashtable]::new()
-	$Folder.Items() | ForEach-Object -Process { $Files.Add($_.Name, $_) } | Out-Null
+	$Folder.Items() | ForEach-Object -Process {$Files.Add($_.Name, $_)} | Out-Null
 	# Find the necessary .msi with the Subject property equal to "Windows PC Health Check"
 	foreach ($MSI in @(Get-ChildItem -Path "$env:SystemRoot\Installer" -Filter *.msi -File -Force))
 	{
-		$name = $Files.Keys | Where-Object -FilterScript { $_ -eq $MSI.Name }
+		$name = $Files.Keys | Where-Object -FilterScript {$_ -eq $MSI.Name}
 		$File = $Files[$name]
 
 		# https://learn.microsoft.com/en-us/previous-versions/tn-archive/ee176615(v=technet.10)

--- a/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
+++ b/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
@@ -9025,8 +9025,8 @@ function UninstallPCHealthCheck
 	# Find the necessary .msi with the Subject property equal to "Windows PC Health Check"
 	foreach ($MSI in @(Get-ChildItem -Path "$env:SystemRoot\Installer" -Filter *.msi -File -Force))
 	{
-		$name = $Files.Keys | Where-Object -FilterScript {$_ -eq $MSI.Name}
-		$File = $Files[$name]
+		$Name = $Files.Keys | Where-Object -FilterScript {$_ -eq $MSI.Name}
+		$File = $Files[$Name]
 
 		# https://learn.microsoft.com/en-us/previous-versions/tn-archive/ee176615(v=technet.10)
 		# "22" is the "Subject" file property

--- a/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
+++ b/src/Sophia_Script_for_Windows_10/Module/Sophia.psm1
@@ -9020,10 +9020,13 @@ public static void Refresh()
 function UninstallPCHealthCheck
 {
 	$Folder = (New-Object -ComObject Shell.Application).NameSpace("$env:SystemRoot\Installer")
+	$Files = [hashtable]::new()
+	$Folder.Items() | ForEach-Object -Process { $Files.Add($_.Name, $_) } | Out-Null
 	# Find the necessary .msi with the Subject property equal to "Windows PC Health Check"
 	foreach ($MSI in @(Get-ChildItem -Path "$env:SystemRoot\Installer" -Filter *.msi -File -Force))
 	{
-		$File = $Folder.Items() | Where-Object -FilterScript {$_.Name -eq $MSI.Name}
+		$name = $Files.Keys | Where-Object -FilterScript { $_ -eq $MSI.Name }
+		$File = $Files[$name]
 
 		# https://learn.microsoft.com/en-us/previous-versions/tn-archive/ee176615(v=technet.10)
 		# "22" is the "Subject" file property

--- a/src/Sophia_Script_for_Windows_10_PowerShell_7/Module/Sophia.psm1
+++ b/src/Sophia_Script_for_Windows_10_PowerShell_7/Module/Sophia.psm1
@@ -9028,10 +9028,13 @@ public static void Refresh()
 function UninstallPCHealthCheck
 {
 	$Folder = (New-Object -ComObject Shell.Application).NameSpace("$env:SystemRoot\Installer")
+	$Files = [hashtable]::new()
+	$Folder.Items() | ForEach-Object -Process { $Files.Add($_.Name, $_) } | Out-Null
 	# Find the necessary .msi with the Subject property equal to "Windows PC Health Check"
 	foreach ($MSI in @(Get-ChildItem -Path "$env:SystemRoot\Installer" -Filter *.msi -File -Force))
 	{
-		$File = $Folder.Items() | Where-Object -FilterScript {$_.Name -eq $MSI.Name}
+		$name = $Files.Keys | Where-Object -FilterScript { $_ -eq $MSI.Name }
+		$File = $Files[$name]
 
 		# https://learn.microsoft.com/en-us/previous-versions/tn-archive/ee176615(v=technet.10)
 		# "22" is the "Subject" file property

--- a/src/Sophia_Script_for_Windows_10_PowerShell_7/Module/Sophia.psm1
+++ b/src/Sophia_Script_for_Windows_10_PowerShell_7/Module/Sophia.psm1
@@ -9029,12 +9029,12 @@ function UninstallPCHealthCheck
 {
 	$Folder = (New-Object -ComObject Shell.Application).NameSpace("$env:SystemRoot\Installer")
 	$Files = [hashtable]::new()
-	$Folder.Items() | ForEach-Object -Process { $Files.Add($_.Name, $_) } | Out-Null
+	$Folder.Items() | ForEach-Object -Process {$Files.Add($_.Name, $_)} | Out-Null
 	# Find the necessary .msi with the Subject property equal to "Windows PC Health Check"
 	foreach ($MSI in @(Get-ChildItem -Path "$env:SystemRoot\Installer" -Filter *.msi -File -Force))
 	{
-		$name = $Files.Keys | Where-Object -FilterScript { $_ -eq $MSI.Name }
-		$File = $Files[$name]
+		$Name = $Files.Keys | Where-Object -FilterScript {$_ -eq $MSI.Name}
+		$File = $Files[$Name]
 
 		# https://learn.microsoft.com/en-us/previous-versions/tn-archive/ee176615(v=technet.10)
 		# "22" is the "Subject" file property


### PR DESCRIPTION
Before:
```
C:\Windows\Installer\35825.msi

Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 37
Milliseconds      : 944
Ticks             : 979443417
TotalDays         : 0.00113361506597222
TotalHours        : 0.0272067615833333
TotalMinutes      : 1.632405695
TotalSeconds      : 97.9443417
TotalMilliseconds : 97944.3417
```
After:
```
C:\Windows\Installer\35825.msi

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 6
Milliseconds      : 699
Ticks             : 66991853
TotalDays         : 7.75368668981482E-05
TotalHours        : 0.00186088480555556
TotalMinutes      : 0.111653088333333
TotalSeconds      : 6.6991853
TotalMilliseconds : 6699.1853
```

I measured time until `$Folder.GetDetailsOf($File, 22) -eq "Windows PC Health Check"` condition is **true**.

Additional info:
```
(New-Object -ComObject Shell.Application).NameSpace("$env:SystemRoot\Installer").Items().Count
1243
```
